### PR TITLE
Fix Trivy path in CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,9 @@ jobs:
 
     - name: Build Docker Image
       run: docker build -t flask-app .
-      
+
     - name: Run security scan with Trivy
       run: |
-        curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh
+        curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
+        trivy --version
         trivy image flask-app


### PR DESCRIPTION
Ten pull request aktualizuje pipeline CI, aby naprawić ścieżkę instalacji Trivy. 

- Zaktualizowano polecenie instalacji Trivy.
- Zweryfikowano wersję Trivy oraz kroki skanowania obrazów.